### PR TITLE
fixed $.offset().top usage

### DIFF
--- a/scripts/jquery.parallax-1.1.3.js
+++ b/scripts/jquery.parallax-1.1.3.js
@@ -26,8 +26,8 @@ http://www.gnu.org/licenses/gpl.html
 		var paddingTop = 0;
 		
 		//get the starting position of each element to have parallax applied to it		
-		$this.each(function(){
-		    firstTop = $this.offset().top;
+		$this.each(function(i,e){
+		    firstTop = $(e).offset().top;
 		});
 
 		if (outerHeight) {


### PR DESCRIPTION
As per API definition offset() returns the position of the FIRST element, using $this will cause to return always the same value.
