### PR TITLE
Fixes an offset-bug on pages that use multiple parallax images

### DIFF
--- a/scripts/jquery.parallax-1.1.3.js
+++ b/scripts/jquery.parallax-1.1.3.js
@@ -26,8 +26,8 @@ http://www.gnu.org/licenses/gpl.html
 		var paddingTop = 0;
 		
 		//get the starting position of each element to have parallax applied to it		
-		$this.each(function(){
-		    firstTop = $this.offset().top;
+		$this.each(function(i,e){
+		    firstTop = $(e).offset().top;
 		});
 
 		if (outerHeight) {

--- a/scripts/jquery.parallax-1.1.3.js
+++ b/scripts/jquery.parallax-1.1.3.js
@@ -22,13 +22,12 @@ http://www.gnu.org/licenses/gpl.html
 	$.fn.parallax = function(xpos, speedFactor, outerHeight) {
 		var $this = $(this);
 		var getHeight;
-		var firstTop;
 		var paddingTop = 0;
 		
 		//get the starting position of each element to have parallax applied to it		
 		$this.each(function(i,e){
-		    $e = $(e);
-		    $e.data('firstTop', $e.offset().top);
+		    $element = $(e);
+		    $element.data('firstTop', $element.offset().top);
 		});
 
 		if (outerHeight) {
@@ -60,7 +59,7 @@ http://www.gnu.org/licenses/gpl.html
 					return;
 				}
 
-				$element.css('backgroundPosition', xpos + " " + Math.round(( $e.data('firstTop') - pos) * speedFactor) + "px");
+				$element.css('backgroundPosition', xpos + " " + Math.round(( $element.data('firstTop') - pos) * speedFactor) + "px");
 			});
 		}		
 

--- a/scripts/jquery.parallax-1.1.3.js
+++ b/scripts/jquery.parallax-1.1.3.js
@@ -27,7 +27,8 @@ http://www.gnu.org/licenses/gpl.html
 		
 		//get the starting position of each element to have parallax applied to it		
 		$this.each(function(i,e){
-		    firstTop = $(e).offset().top;
+		    $e = $(e);
+		    $e.data('firstTop', $e.offset().top);
 		});
 
 		if (outerHeight) {
@@ -49,8 +50,8 @@ http://www.gnu.org/licenses/gpl.html
 		function update(){
 			var pos = $window.scrollTop();				
 
-			$this.each(function(){
-				var $element = $(this);
+			$this.each(function(i,e){
+				var $element = $(e);
 				var top = $element.offset().top;
 				var height = getHeight($element);
 
@@ -59,7 +60,7 @@ http://www.gnu.org/licenses/gpl.html
 					return;
 				}
 
-				$this.css('backgroundPosition', xpos + " " + Math.round((firstTop - pos) * speedFactor) + "px");
+				$element.css('backgroundPosition', xpos + " " + Math.round(( $e.data('firstTop') - pos) * speedFactor) + "px");
 			});
 		}		
 


### PR DESCRIPTION
Currently the script stores only the offset().top of the first element matched by jQuery, it should instead store top for every element. 
